### PR TITLE
fix(zhihu): 修复评论区内容不会随侧边面板宽度缩窄自适应的问题

### DIFF
--- a/zhihu/src/components/CommentItem.tsx
+++ b/zhihu/src/components/CommentItem.tsx
@@ -69,7 +69,7 @@ const CommentItem: React.FC<{ comment: ZhihuCommentItem }> = ({ comment }) => {
           src={comment.author.avatar_url}
           style={{ borderRadius: 8, flexShrink: 0 }}
         />
-        <div style={{ flex: 1 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
           <span style={{ fontWeight: "bold" }}>
             {comment.author.name}
             {comment.reply_to_author ? (

--- a/zhihu/src/style/index.less
+++ b/zhihu/src/style/index.less
@@ -358,9 +358,23 @@ a {
 
 .comment-content {
   line-height: 2;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  overflow: hidden;
   span {
     p {
       margin: 0;
     }
+  }
+  img {
+    max-width: 100%;
+  }
+}
+
+/* 评论列表容器 — 防止内容撑开父容器 */
+.comment-list {
+  overflow: hidden;
+  .ant-list-item {
+    overflow: hidden;
   }
 }


### PR DESCRIPTION
- CommentItem 内容容器添加 minWidth: 0，允许 flex 子项缩小
- .comment-content 添加 word-break/overflow-wrap 防止长文本溢出
- 新增 .comment-list 样式约束列表项溢出